### PR TITLE
🐛 fix: correct import case for Portfolio component in App.tsx

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import Portfolio from "./components/portfolio"
+import Portfolio from "./components/Portfolio"
 
 
 function App() {


### PR DESCRIPTION
This pull request includes a small change to the `client/src/App.tsx` file. The change corrects the import statement to use the proper case for the `Portfolio` component.